### PR TITLE
android 16 target for xgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ geth-windows-amd64: xgo
 	@ls -ld $(GOBIN)/geth-windows-* | grep amd64
 
 geth-android: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=android-21/aar -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=android-16/aar -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Android cross compilation done:"
 	@ls -ld $(GOBIN)/geth-android-*
 


### PR DESCRIPTION
This seems to be consistent with `xgo` syntax and previous changes on the status-im fork (if those worked).  The `make geth-android` completed without error:

```
Cleaning up build environment...
Android cross compilation done:
-rw-r--r-- 1 root root 16858846 May 30 08:39 build/bin/geth-android-16.aar
```