### PR TITLE
--noeth flag with peer discovery, compatible w/ shh

### DIFF
--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -161,6 +161,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.WhisperEnabledFlag,
 			utils.NatspecEnabledFlag,
+			utils.NoEthFlag,
 		},
 	},
 	{

--- a/node/node.go
+++ b/node/node.go
@@ -176,6 +176,7 @@ func (n *Node) Start() error {
 		}
 		services[kind] = service
 	}
+
 	// Gather the protocols and start the freshly assembled P2P server
 	for _, service := range services {
 		running.Protocols = append(running.Protocols, service.Protocols()...)


### PR DESCRIPTION
Added a `--noeth` flag.  This flag disables the `eth` service, but still allow peer discovery via the p2p server and will work with the `--shh` flag.  Thus you can run Whisper without eth still maintaining discovery.

Confirmed (I think) by running with the console:

```
dwhitena@dirac:go-ethereum$ build/bin/geth --shh --noeth console
I0531 09:34:36.472076 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /home/dwhitena/.ethereum/chaindata
I0531 09:34:36.478234 ethdb/database.go:169] closed db:/home/dwhitena/.ethereum/chaindata
I0531 09:34:36.478661 p2p/server.go:311] Starting Server
I0531 09:34:38.933898 p2p/discover/udp.go:217] Listening, enode://dcb63a9c4dc6b87e4e9892c962411ff7b095a6a7daf5f28abb4a76b2f32542a6a81b8693d97789bba67861ece59c380cc8a46ea0b23c12a77ba9c2046b149f63@[::]:30303
I0531 09:34:38.934098 whisper/whisper.go:176] Whisper started
I0531 09:34:38.934201 p2p/server.go:554] Listening on [::]:30303
I0531 09:34:38.934515 node/node.go:299] IPC endpoint opened: /home/dwhitena/.ethereum/geth.ipc
instance: Geth/v1.4.5-stable-578738f6/linux/go1.6
>
```

And we can then see if we connect to peers:

```
> admin.peers
[{
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "33b9676c6692f4b634868957c52db42094eacbd0eb9e2807bde188cf677956ff2b8a8ea25c3f5a58f8c99505013d9ddb830c0b2f184b63e776e8e6349a1c3245",
    name: "Geth/eth-peer-tok02-6/v1.3.5-34b622a2/linux/go1.6",
    network: {
      localAddress: "192.168.254.38:33838",
      remoteAddress: "161.202.82.6:40404"
    },
    protocols: {
      shh: "unknown"
    }
}, {
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "ae2d85fc36cc1238eb584a86179986b8d283aab63174c9762124f498866ca984f1d5b38101fedb8d0c58df89e2663c508efd055a6619f5265dbfff70a12bb486",
    name: "Geth/eth-peer-dal09-7/v1.3.5-34b622a2/linux/go1.6",
    network: {
      localAddress: "192.168.254.38:60264",
      remoteAddress: "169.45.159.38:40404"
    },
    protocols: {
      shh: "unknown"
    }
}, {
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "d1d695e97d3b16972717b6acf503b39756f4fe96a31c4006670ced5a95e829dddd4eee641720f0a2cef8be86134693830a2f14e5aba32876543e4b443f11002e",
    name: "Geth/v1.4.3-stable/linux/go1.5.1/chainthat_miner",
    network: {
      localAddress: "192.168.254.38:45406",
      remoteAddress: "91.223.16.100:30303"
    },
    protocols: {
      shh: "unknown"
    }
}]
```

Note, we stay connected to these peers (we are not kicked off because we don't have eth).  This is because the handshake is just a loop over all protocols.  This behavior can be confirmed by running `admin.peers` twice to see the same plus other peers.