### PR TITLE
android 16 including light-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ geth-windows-amd64: xgo
 	@ls -ld $(GOBIN)/geth-windows-* | grep amd64
 
 geth-android: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=android-21/aar -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=android-16/aar -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Android cross compilation done:"
 	@ls -ld $(GOBIN)/geth-android-*
 


### PR DESCRIPTION
Similar to what we did in `status-mod` here https://github.com/status-im/go-ethereum/pull/1.  This time including light-api.  Successfully built:

```
Cleaning up build environment...
Android cross compilation done:
-rw-r--r-- 1 root root 17301732 Jun  2 12:00 build/bin/geth-android-16.aar
```