### PR TITLE
shh and noeth compatible with light-api

### DIFF
--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -164,6 +164,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.WhisperEnabledFlag,
 			utils.NatspecEnabledFlag,
+			utils.NoEthFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -361,6 +361,10 @@ var (
 		Name:  "nodiscover",
 		Usage: "Disables the peer discovery mechanism (manual peer addition)",
 	}
+	NoEthFlag = cli.BoolFlag{
+		Name:  "noeth",
+		Usage: "Disable eth Protocol",
+	}
 	WhisperEnabledFlag = cli.BoolFlag{
 		Name:  "shh",
 		Usage: "Enable Whisper",
@@ -708,8 +712,8 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		Genesis:                 MakeGenesisBlock(ctx),
 		FastSync:                ctx.GlobalBool(FastSyncFlag.Name),
 		LightMode:               ctx.GlobalBool(LightModeFlag.Name),
-		LightServ:				  ctx.GlobalInt(LightServFlag.Name),
-		LightPeers:				  ctx.GlobalInt(LightPeersFlag.Name),
+		LightServ:               ctx.GlobalInt(LightServFlag.Name),
+		LightPeers:              ctx.GlobalInt(LightPeersFlag.Name),
 		BlockChainVersion:       ctx.GlobalInt(BlockchainVersionFlag.Name),
 		DatabaseCache:           ctx.GlobalInt(CacheFlag.Name),
 		DatabaseHandles:         MakeDatabaseHandles(),
@@ -734,6 +738,9 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 	}
 	// Configure the Whisper service
 	shhEnable := ctx.GlobalBool(WhisperEnabledFlag.Name)
+
+	// Configure the Ethereum service
+	ethDisable := ctx.GlobalBool(NoEthFlag.Name)
 
 	// Override any default configs in dev mode or the test net
 	switch {
@@ -778,6 +785,7 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		}
 		ethConf.PowTest = true
 	}
+
 	// Assemble and return the protocol stack
 	stack, err := node.New(stackConf)
 	if err != nil {
@@ -789,35 +797,42 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 	}); err != nil {
 		Fatalf("Failed to register the account manager service: %v", err)
 	}
-	
-	if ethConf.LightMode {
-		if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
-			return les.New(ctx, ethConf)
-		}); err != nil {
-			Fatalf("Failed to register the Ethereum light node service: %v", err)
-		}
-	} else {
-		if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
-			fullNode, err := eth.New(ctx, ethConf)
-			if fullNode != nil {
-				ls, _ := les.NewLesServer(fullNode, ethConf)
-				fullNode.AddLesServer(ls)
+
+	if !ethDisable {
+		if ethConf.LightMode {
+			if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+				return les.New(ctx, ethConf)
+			}); err != nil {
+				Fatalf("Failed to register the Ethereum light node service: %v", err)
 			}
-			return fullNode, err
-		}); err != nil {
-			Fatalf("Failed to register the Ethereum full node service: %v", err)
+		} else {
+			if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+				fullNode, err := eth.New(ctx, ethConf)
+				if fullNode != nil {
+					ls, _ := les.NewLesServer(fullNode, ethConf)
+					fullNode.AddLesServer(ls)
+				}
+				return fullNode, err
+			}); err != nil {
+				Fatalf("Failed to register the Ethereum full node service: %v", err)
+			}
+			if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+				return release.NewReleaseService(ctx, relconf)
+			}); err != nil {
+				Fatalf("Failed to register the Geth release oracle service: %v", err)
+			}
+
 		}
 	}
+
 	if shhEnable {
-		if err := stack.Register(func(*node.ServiceContext) (node.Service, error) { return whisper.New(), nil }); err != nil {
+		if err := stack.Register(func(*node.ServiceContext) (node.Service, error) {
+			return whisper.New(), nil
+		}); err != nil {
 			Fatalf("Failed to register the Whisper service: %v", err)
 		}
 	}
-	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
-		return release.NewReleaseService(ctx, relconf)
-	}); err != nil {
-		Fatalf("Failed to register the Geth release oracle service: %v", err)
-	}
+
 	return stack
 }
 


### PR DESCRIPTION
This adds our noeth functionality to the develop branch with light-api.  Thus, we can do the following:

Run just whisper without eth or light:
```
build/bin/geth --noeth --shh
```

Run whisper with light:
```
build/bin/geth --light --shh
```

Or run light without whisper:
```
build/bin/geth --light
```

Note, that all but `--light` by itself allows for peer discovery.  I think this peer discovery issue (alluded to by the LES guys on gitter, etc.) must be an internal LES issue independent from our subprotocol functionality.  Here is my evidence for that:

(1) I can run `--noeth --shh` and get peer discovery:
```
dwhitena@dirac:go-ethereum$ build/bin/geth --noeth --shh console
I0602 13:35:36.520574 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /home/dwhitena/.ethereum/chaindata
I0602 13:35:36.545276 ethdb/database.go:169] closed db:/home/dwhitena/.ethereum/chaindata
*accounts.Manager
I0602 13:35:36.545843 p2p/server.go:311] Starting Server
I0602 13:35:38.954362 p2p/discover/udp.go:217] Listening, enode://dcb63a9c4dc6b87e4e9892c962411ff7b095a6a7daf5f28abb4a76b2f32542a6a81b8693d97789bba67861ece59c380cc8a46ea0b23c12a77ba9c2046b149f63@[::]:30303
I0602 13:35:38.954924 whisper/whisper.go:176] Whisper started
I0602 13:35:38.955090 p2p/server.go:554] Listening on [::]:30303
I0602 13:35:38.956840 node/node.go:300] IPC endpoint opened: /home/dwhitena/.ethereum/geth.ipc
instance: Geth/v1.5.0-unstable-03f2db5f/linux/go1.6
> admin.peers
[]
> admin.peers
[]
> admin.peers
[]
> admin.peers
[]
> admin.peers
[{
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "0fa7e4b1b52339cf5ccf6217c5e69505e484f2a786a0a59f5780d12023d94e798ffb3dce16e84ce7c557230cd84895be452ab965bba11d43ad42c113568215d1",
    name: "Geth/eth-peer-dal09-6/v1.3.5-34b622a2/linux/go1.6",
    network: {
      localAddress: "192.168.254.38:47252",
      remoteAddress: "169.45.159.58:40404"
    },
    protocols: {
      shh: "unknown"
    }
}, {
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "d2ebc856629beb88d19140e2c23476340c61c6f04508fcc86553dee0c9d8b4ff7a426e51c97fbf2c4e26d0103020b8c752a9e8a3200cb93b38ded4e871aa0a92",
    name: "Geth/v1.4.3-stable/linux/go1.5.1/aws_node1",
    network: {
      localAddress: "192.168.254.38:36200",
      remoteAddress: "52.27.41.212:30303"
    },
    protocols: {
      shh: "unknown"
    }
}, {
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "dda183d14f197728f01fc3c1128b78c431810c7d12a9d20153afb3e480830775a43ea611fea29ea471dd8cbd40c06ae6bc6a3ff6b75bcb88be7cb3c08a96ddc4",
    name: "Geth/eth-peer-tok02-2/v1.3.5-34b622a2/linux/go1.6",
    network: {
      localAddress: "192.168.254.38:58422",
      remoteAddress: "161.202.82.12:40404"
    },
    protocols: {
      shh: "unknown"
    }
}]
```

(2) I can run `-shh -light` and get peer discovery:
```
dwhitena@dirac:go-ethereum$ build/bin/geth --light --shh console
I0602 13:37:36.876675 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /home/dwhitena/.ethereum/chaindata
I0602 13:37:36.885268 ethdb/database.go:169] closed db:/home/dwhitena/.ethereum/chaindata
*accounts.Manager
I0602 13:37:36.885705 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /home/dwhitena/.ethereum/chaindata
I0602 13:37:36.898911 ethdb/database.go:82] Alloted 16MB cache and 16 file handles to /home/dwhitena/.ethereum/dapp
I0602 13:37:36.902080 light/lightchain.go:141] Last header: #26688 [486883fc…] TD=17670603983400860
*accounts.Manager
*les.LightNodeService
I0602 13:37:36.902347 p2p/server.go:311] Starting Server
I0602 13:37:39.341480 p2p/discover/udp.go:217] Listening, enode://dcb63a9c4dc6b87e4e9892c962411ff7b095a6a7daf5f28abb4a76b2f32542a6a81b8693d97789bba67861ece59c380cc8a46ea0b23c12a77ba9c2046b149f63@[::]:30303
I0602 13:37:39.341963 whisper/whisper.go:176] Whisper started
I0602 13:37:39.342131 p2p/server.go:554] Listening on [::]:30303
I0602 13:37:39.342778 node/node.go:300] IPC endpoint opened: /home/dwhitena/.ethereum/geth.ipc
instance: Geth/v1.5.0-unstable-03f2db5f/linux/go1.6
> admin.peers
[]
> admin.peers
[]
> admin.peers
[{
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "31d9a3079a21ef4ebceb6ab3644a707ab40844f2233bab4302cfccfe61b1ab8f5028170e1505481697b52fd2088a0340d376859c0111d1fdc4ea1f9be8eda38e",
    name: "Geth/eth-miner-dal09-1/v1.3.5-34b622a2/linux/go1.6",
    network: {
      localAddress: "192.168.254.38:58234",
      remoteAddress: "169.45.159.45:40404"
    },
    protocols: {
      shh: "unknown"
    }
}, {
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "a444bb2227f9cb4ecddbab19976c2472c8ec9a0508da19702dfc7bdeb902e023f1cf71d937125c041c427246a790de83a3fedc92546eb03174a2a991810025ec",
    name: "Geth/eth-peer-lon02-3/v1.3.5-34b622a2/linux/go1.6",
    network: {
      localAddress: "192.168.254.38:37224",
      remoteAddress: "159.122.239.100:40404"
    },
    protocols: {
      shh: "unknown"
    }
}, {
    caps: ["eth/61", "eth/62", "eth/63", "shh/2"],
    id: "f9b63a819ef9e4111fb482b20d4cc6db85fd02c164a1ff2f0a3463046379c6a26ee4ceeee222fa23e53185b0712911f785a839aa08fb2357f0db6aba144f8b78",
    name: "Geth/v1.3.5-34b622a2/linux/go1.6",
    network: {
      localAddress: "192.168.254.38:56140",
      remoteAddress: "159.203.21.106:30303"
    },
    protocols: {
      shh: "unknown"
    }
}]
```

(3) But if I spin up with `--light` only, I cannot discover peer (likely because there are none):
```
dwhitena@dirac:go-ethereum$ build/bin/geth --light console
I0602 13:43:59.786596 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /home/dwhitena/.ethereum/chaindata
I0602 13:43:59.820565 ethdb/database.go:169] closed db:/home/dwhitena/.ethereum/chaindata
*accounts.Manager
I0602 13:43:59.821002 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /home/dwhitena/.ethereum/chaindata
I0602 13:43:59.837709 ethdb/database.go:82] Alloted 16MB cache and 16 file handles to /home/dwhitena/.ethereum/dapp
I0602 13:43:59.842635 light/lightchain.go:141] Last header: #26688 [486883fc…] TD=17670603983400860
I0602 13:43:59.842901 p2p/server.go:311] Starting Server
I0602 13:44:02.235215 p2p/discover/udp.go:217] Listening, enode://dcb63a9c4dc6b87e4e9892c962411ff7b095a6a7daf5f28abb4a76b2f32542a6a81b8693d97789bba67861ece59c380cc8a46ea0b23c12a77ba9c2046b149f63@[::]:30303
I0602 13:44:02.235794 p2p/server.go:554] Listening on [::]:30303
I0602 13:44:02.235868 node/node.go:300] IPC endpoint opened: /home/dwhitena/.ethereum/geth.ipc
instance: Geth/v1.5.0-unstable-03f2db5f/linux/go1.6
> admin.peers
[]
> admin.peers
[]
> admin.peers
[]
> admin.peers
[]
> admin.peers
[]
> admin.peers
[]
> admin.peers
[]
```

However, I cannot manually add light peers either.  Looking into the logs we can see that the les handshake is failing:

``` 
> {f28abb4a76b2f32542a6a81b8693d97789bba67861ece59c380cc8a46ea0b23c12a77ba9c2046b149f63@[::]:30303')
I0602 14:03:27.778220 p2p/dial.go:263] dial tcp [::]:30303 (dcb63a9c4dc6)
true
> I0602 14:03:27.782637 p2p/dial.go:263] dial tcp 45.32.157.49:53900 (939a0be8a1b1)
I0602 14:03:27.791924 p2p/server.go:672] Added Peer dcb63a9c4dc6b87e [::1]:30303
I0602 14:03:27.792745 les/handler.go:251] Peer dcb63a9c4dc6b87e [les/1]: peer connected [Geth/v1.5.0-unstable-03f2db5f/linux/go1.6]
I0602 14:03:27.794186 les/handler.go:256] Peer dcb63a9c4dc6b87e [les/1]: handshake failed:  - peer cannot serve chain
I0602 14:03:27.794334 p2p/peer.go:177] Peer dcb63a9c4dc6b87e [::1]:30303: protocol error:  - peer cannot serve chain (Subprotocol error)
```

That error is generate at line 333 of `les/peer.go` (which seems to happen within LES).