### PR TITLE
Account sync and injection for subprotocols (e.g., whisper)

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -222,7 +222,7 @@ func (am *Manager) TimedUnlock(a Account, passphrase string, timeout time.Durati
 func (am *Manager) syncAccounts(a string, key *Key) error {
 	for _, service := range *am.sync {
 		if whisperInstance, ok := service.(*whisper.Whisper); ok && key.WhisperEnabled {
-			err := whisperInstance.InjectIdentity(a, key.PrivateKey)
+			err := whisperInstance.InjectIdentity(key.PrivateKey)
 			if err != nil {
 				return fmt.Errorf("failed to sync accounts with shh: %s", err.Error())
 			}

--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -237,8 +237,8 @@ func (am *Manager) expire(addr common.Address, u *unlocked, timeout time.Duratio
 
 // NewAccount generates a new key and stores it into the key directory,
 // encrypting it with the passphrase.
-func (am *Manager) NewAccount(passphrase string) (Account, error) {
-	_, account, err := storeNewKey(am.keyStore, crand.Reader, passphrase)
+func (am *Manager) NewAccount(passphrase string, w bool) (Account, error) {
+	_, account, err := storeNewKey(am.keyStore, crand.Reader, passphrase, w)
 	if err != nil {
 		return Account{}, err
 	}

--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -34,8 +34,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/whisper"
 )
 
 var (
@@ -70,6 +72,7 @@ type Manager struct {
 	keyStore keyStore
 	mu       sync.RWMutex
 	unlocked map[common.Address]*unlocked
+	sync     *[]node.Service
 }
 
 type unlocked struct {
@@ -78,9 +81,12 @@ type unlocked struct {
 }
 
 // NewManager creates a manager for the given directory.
-func NewManager(keydir string, scryptN, scryptP int) *Manager {
+func NewManager(keydir string, scryptN, scryptP int, s *[]node.Service) *Manager {
 	keydir, _ = filepath.Abs(keydir)
-	am := &Manager{keyStore: &keyStorePassphrase{keydir, scryptN, scryptP}}
+	am := &Manager{
+		keyStore: &keyStorePassphrase{keydir, scryptN, scryptP},
+		sync:     s,
+	}
 	am.init(keydir)
 	return am
 }
@@ -174,9 +180,19 @@ func (am *Manager) Lock(addr common.Address) error {
 // shortens the active unlock timeout. If the address was previously unlocked
 // indefinitely the timeout is not altered.
 func (am *Manager) TimedUnlock(a Account, passphrase string, timeout time.Duration) error {
+
 	a, key, err := am.getDecryptedKey(a, passphrase)
 	if err != nil {
 		return err
+	}
+
+	// sync key to subprotocols (e.g., whisper identity)
+	if am.sync != nil {
+		address := fmt.Sprintf("%x", a.Address)
+		err = am.syncAccounts(address, key)
+		if err != nil {
+			return fmt.Errorf("failed to sync accounts: %s", err.Error())
+		}
 	}
 
 	am.mu.Lock()
@@ -200,6 +216,18 @@ func (am *Manager) TimedUnlock(a Account, passphrase string, timeout time.Durati
 		u = &unlocked{Key: key}
 	}
 	am.unlocked[a.Address] = u
+	return nil
+}
+
+func (am *Manager) syncAccounts(a string, key *Key) error {
+	for _, service := range *am.sync {
+		if whisperInstance, ok := service.(*whisper.Whisper); ok && key.WhisperEnabled {
+			err := whisperInstance.InjectIdentity(a, key.PrivateKey)
+			if err != nil {
+				return fmt.Errorf("failed to sync accounts with shh: %s", err.Error())
+			}
+		}
+	}
 	return nil
 }
 
@@ -238,13 +266,25 @@ func (am *Manager) expire(addr common.Address, u *unlocked, timeout time.Duratio
 // NewAccount generates a new key and stores it into the key directory,
 // encrypting it with the passphrase.
 func (am *Manager) NewAccount(passphrase string, w bool) (Account, error) {
-	_, account, err := storeNewKey(am.keyStore, crand.Reader, passphrase, w)
+
+	key, account, err := storeNewKey(am.keyStore, crand.Reader, passphrase, w)
 	if err != nil {
 		return Account{}, err
 	}
+
 	// Add the account to the cache immediately rather
 	// than waiting for file system notifications to pick it up.
 	am.cache.add(account)
+
+	// sync key to subprotocols (e.g., whisper identity)
+	if am.sync != nil {
+		address := fmt.Sprintf("%x", account.Address)
+		err = am.syncAccounts(address, key)
+		if err != nil {
+			return account, fmt.Errorf("failed to sync accounts: %s", err.Error())
+		}
+	}
+
 	return account, nil
 }
 

--- a/accounts/key.go
+++ b/accounts/key.go
@@ -68,10 +68,11 @@ type plainKeyJSON struct {
 }
 
 type encryptedKeyJSONV3 struct {
-	Address string     `json:"address"`
-	Crypto  cryptoJSON `json:"crypto"`
-	Id      string     `json:"id"`
-	Version int        `json:"version"`
+	Address        string     `json:"address"`
+	Crypto         cryptoJSON `json:"crypto"`
+	Id             string     `json:"id"`
+	Version        int        `json:"version"`
+	WhisperEnabled bool       `json:"whisperenabled"`
 }
 
 type encryptedKeyJSONV1 struct {
@@ -183,9 +184,7 @@ func storeNewKey(ks keyStore, rand io.Reader, auth string, w bool) (*Key, Accoun
 	if err != nil {
 		return nil, Account{}, err
 	}
-	if w {
-		key.WhisperEnabled = true
-	}
+	key.WhisperEnabled = w
 	a := Account{Address: key.Address, File: ks.JoinPath(keyFileName(key.Address))}
 	if err := ks.StoreKey(a.File, key, auth); err != nil {
 		zeroKey(key.PrivateKey)

--- a/accounts/key.go
+++ b/accounts/key.go
@@ -46,6 +46,9 @@ type Key struct {
 	// we only store privkey as pubkey/address can be derived from it
 	// privkey in this struct is always in plaintext
 	PrivateKey *ecdsa.PrivateKey
+	// if whisper is enabled here, the address will be used as a whisper
+	// identity upon creation of the account or unlocking of the account
+	WhisperEnabled bool
 }
 
 type keyStore interface {
@@ -175,10 +178,13 @@ func newKey(rand io.Reader) (*Key, error) {
 	return newKeyFromECDSA(privateKeyECDSA), nil
 }
 
-func storeNewKey(ks keyStore, rand io.Reader, auth string) (*Key, Account, error) {
+func storeNewKey(ks keyStore, rand io.Reader, auth string, w bool) (*Key, Account, error) {
 	key, err := newKey(rand)
 	if err != nil {
 		return nil, Account{}, err
+	}
+	if w {
+		key.WhisperEnabled = true
 	}
 	a := Account{Address: key.Address, File: ks.JoinPath(keyFileName(key.Address))}
 	if err := ks.StoreKey(a.File, key, auth); err != nil {

--- a/accounts/key_store_passphrase.go
+++ b/accounts/key_store_passphrase.go
@@ -140,6 +140,7 @@ func EncryptKey(key *Key, auth string, scryptN, scryptP int) ([]byte, error) {
 		cryptoStruct,
 		key.Id.String(),
 		version,
+		key.WhisperEnabled,
 	}
 	return json.Marshal(encryptedKeyJSONV3)
 }
@@ -175,9 +176,10 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	}
 	key := crypto.ToECDSA(keyBytes)
 	return &Key{
-		Id:         uuid.UUID(keyId),
-		Address:    crypto.PubkeyToAddress(key.PublicKey),
-		PrivateKey: key,
+		Id:             uuid.UUID(keyId),
+		Address:        crypto.PubkeyToAddress(key.PublicKey),
+		PrivateKey:     key,
+		WhisperEnabled: m["whisperenabled"].(bool),
 	}, nil
 }
 

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/node"
 )
 
 var (
@@ -167,7 +168,8 @@ nodes.
 )
 
 func accountList(ctx *cli.Context) {
-	accman := utils.MakeAccountManager(ctx)
+	var sync *[]node.Service
+	accman := utils.MakeAccountManager(ctx, sync)
 	for i, acct := range accman.Accounts() {
 		fmt.Printf("Account #%d: {%x} %s\n", i, acct.Address, acct.File)
 	}
@@ -276,7 +278,8 @@ func ambiguousAddrRecovery(am *accounts.Manager, err *accounts.AmbiguousAddrErro
 
 // accountCreate creates a new account into the keystore defined by the CLI flags.
 func accountCreate(ctx *cli.Context) {
-	accman := utils.MakeAccountManager(ctx)
+	var sync *[]node.Service
+	accman := utils.MakeAccountManager(ctx, sync)
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 	whisper := getWhisperYesNo("You can also choose to enable your new account as a Whisper identity.")
 
@@ -294,7 +297,8 @@ func accountUpdate(ctx *cli.Context) {
 	if len(ctx.Args()) == 0 {
 		utils.Fatalf("No accounts specified to update")
 	}
-	accman := utils.MakeAccountManager(ctx)
+	var sync *[]node.Service
+	accman := utils.MakeAccountManager(ctx, sync)
 
 	account, oldPassword := unlockAccount(ctx, accman, ctx.Args().First(), 0, nil)
 	newPassword := getPassPhrase("Please give a new password. Do not forget this password.", true, 0, nil)
@@ -313,7 +317,8 @@ func importWallet(ctx *cli.Context) {
 		utils.Fatalf("Could not read wallet file: %v", err)
 	}
 
-	accman := utils.MakeAccountManager(ctx)
+	var sync *[]node.Service
+	accman := utils.MakeAccountManager(ctx, sync)
 	passphrase := getPassPhrase("", false, 0, utils.MakePasswordList(ctx))
 
 	acct, err := accman.ImportPreSaleKey(keyJson, passphrase)
@@ -332,7 +337,8 @@ func accountImport(ctx *cli.Context) {
 	if err != nil {
 		utils.Fatalf("keyfile must be given as argument")
 	}
-	accman := utils.MakeAccountManager(ctx)
+	var sync *[]node.Service
+	accman := utils.MakeAccountManager(ctx, sync)
 	passphrase := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 	acct, err := accman.ImportECDSA(key, passphrase)
 	if err != nil {

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -201,7 +201,7 @@ func unlockAccount(ctx *cli.Context, accman *accounts.Manager, address string, i
 	return accounts.Account{}, ""
 }
 
-// getPassPhrase retrieves the passwor associated with an account, either fetched
+// getPassPhrase retrieves the password associated with an account, either fetched
 // from a list of preloaded passphrases, or requested interactively from the user.
 func getPassPhrase(prompt string, confirmation bool, i int, passwords []string) string {
 	// If a list of passwords was supplied, retrieve from them
@@ -229,6 +229,23 @@ func getPassPhrase(prompt string, confirmation bool, i int, passwords []string) 
 		}
 	}
 	return password
+}
+
+// getWhisperYesNo retrieves an indication of whether or not the user wants the created
+// account to also be enabled as a whisper identity
+func getWhisperYesNo(prompt string) bool {
+
+	// prompt the user for the whisper preference
+	if prompt != "" {
+		fmt.Println(prompt)
+	}
+
+	shhRes, err := utils.Stdin.ConfirmPrompt("Enable the new account as a Whisper Identity?")
+	if err != nil {
+		utils.Fatalf("Failed to read response: %v", err)
+	}
+
+	return shhRes
 }
 
 func ambiguousAddrRecovery(am *accounts.Manager, err *accounts.AmbiguousAddrError, auth string) accounts.Account {
@@ -261,11 +278,13 @@ func ambiguousAddrRecovery(am *accounts.Manager, err *accounts.AmbiguousAddrErro
 func accountCreate(ctx *cli.Context) {
 	accman := utils.MakeAccountManager(ctx)
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
+	whisper := getWhisperYesNo("You can also choose to enable your new account as a Whisper identity.")
 
-	account, err := accman.NewAccount(password)
+	account, err := accman.NewAccount(password, whisper)
 	if err != nil {
 		utils.Fatalf("Failed to create account: %v", err)
 	}
+
 	fmt.Printf("Address: {%x}\n", account.Address)
 }
 

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -258,8 +258,8 @@ func (s *PrivateAccountAPI) ListAccounts() []common.Address {
 }
 
 // NewAccount will create a new account and returns the address for the new account.
-func (s *PrivateAccountAPI) NewAccount(password string) (common.Address, error) {
-	acc, err := s.am.NewAccount(password)
+func (s *PrivateAccountAPI) NewAccount(password string, w bool) (common.Address, error) {
+	acc, err := s.am.NewAccount(password, w)
 	if err == nil {
 		return acc.Address, nil
 	}
@@ -310,10 +310,10 @@ func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
 		b: b,
 		newBlockSubscriptions: make(map[string]func(core.ChainEvent) error),
 	}
-	
+
 	go api.subscriptionLoop()
-	
-	return api	
+
+	return api
 }
 
 // subscriptionLoop reads events from the global event mux and creates notifications for the matched subscriptions.
@@ -828,8 +828,8 @@ func newRPCTransaction(b *types.Block, txHash common.Hash) (*RPCTransaction, err
 
 // PublicTransactionPoolAPI exposes methods for the RPC interface
 type PublicTransactionPoolAPI struct {
-	b    Backend
-	txMu sync.Mutex
+	b               Backend
+	txMu            sync.Mutex
 	muPendingTxSubs sync.Mutex
 	pendingTxSubs   map[string]rpc.Subscription
 }
@@ -837,7 +837,7 @@ type PublicTransactionPoolAPI struct {
 // NewPublicTransactionPoolAPI creates a new RPC service with methods specific for the transaction pool.
 func NewPublicTransactionPoolAPI(b Backend) *PublicTransactionPoolAPI {
 	api := &PublicTransactionPoolAPI{
-		b: b,
+		b:             b,
 		pendingTxSubs: make(map[string]rpc.Subscription),
 	}
 

--- a/jsre/ethereum_js.go
+++ b/jsre/ethereum_js.go
@@ -5650,6 +5650,12 @@ var methods = function () {
         params: 1
     });
 
+    var addIdentity = new Method({
+	name: 'addIdentity',
+	call: 'shh_addIdentity',
+	params: 1
+    });
+
     var newGroup = new Method({
         name: 'newGroup',
         call: 'shh_newGroup',
@@ -5666,7 +5672,8 @@ var methods = function () {
         post,
         newIdentity,
         hasIdentity,
-        newGroup,
+        addIdentity,
+	newGroup,
         addToGroup
     ];
 };
@@ -5777,7 +5784,7 @@ var shh = function () {
     });
 
     return [
-        newFilter,
+	newFilter,
         uninstallFilter,
         getLogs,
         poll

--- a/whisper/api.go
+++ b/whisper/api.go
@@ -178,6 +178,9 @@ func (s *PublicWhisperAPI) Post(args PostArgs) (bool, error) {
 
 	// construct whisper message with transmission options
 	message := NewMessage(common.FromHex(args.Payload))
+	if len(message.Payload) == 0 && len(args.Payload) > 0 {
+		message.Payload = []byte(args.Payload)
+	}
 	options := Options{
 		To:     crypto.ToECDSAPub(common.FromHex(args.To)),
 		TTL:    time.Duration(args.TTL) * time.Second,

--- a/whisper/api.go
+++ b/whisper/api.go
@@ -63,7 +63,7 @@ func (s *PublicWhisperAPI) HasIdentity(identity string) (bool, error) {
 	if s.w == nil {
 		return false, whisperOffLineErr
 	}
-	return s.w.HasIdentity(crypto.ToECDSAPub(common.FromHex(identity))), nil
+	return s.w.HasIdentity(identity), nil
 }
 
 // NewIdentity generates a new cryptographic identity for the client, and injects
@@ -81,26 +81,6 @@ type NewFilterArgs struct {
 	To     string
 	From   string
 	Topics [][][]byte
-}
-
-// AddIdentify adds a given hex encoded identity into the known whisper identities
-func (s *PublicWhisperAPI) AddIdentity(identity string) (bool, error) {
-
-	if s.w == nil {
-		return false, whisperOffLineErr
-	}
-
-	key, err := crypto.HexToECDSA(identity)
-	if err != nil {
-		return false, fmt.Errorf("failed to convert identity to ECDSA: %s", err.Error())
-	}
-
-	err = s.w.InjectIdentity(key)
-	if err != nil {
-		return false, fmt.Errorf("failed to inject key in whisper: %s", err.Error())
-	}
-	return true, nil
-
 }
 
 // NewWhisperFilter creates and registers a new message filter to watch for inbound whisper messages.

--- a/whisper/api.go
+++ b/whisper/api.go
@@ -83,6 +83,26 @@ type NewFilterArgs struct {
 	Topics [][][]byte
 }
 
+// AddIdentify adds a given hex encoded identity into the known whisper identities
+func (s *PublicWhisperAPI) AddIdentity(identity string) (bool, error) {
+
+	if s.w == nil {
+		return false, whisperOffLineErr
+	}
+
+	key, err := crypto.HexToECDSA(identity)
+	if err != nil {
+		return false, fmt.Errorf("failed to convert identity to ECDSA: %s", err.Error())
+	}
+
+	err = s.w.InjectIdentity(key)
+	if err != nil {
+		return false, fmt.Errorf("failed to inject key in whisper: %s", err.Error())
+	}
+	return true, nil
+
+}
+
 // NewWhisperFilter creates and registers a new message filter to watch for inbound whisper messages.
 func (s *PublicWhisperAPI) NewFilter(args NewFilterArgs) (*rpc.HexNumber, error) {
 	if s.w == nil {

--- a/whisper/api.go
+++ b/whisper/api.go
@@ -63,7 +63,7 @@ func (s *PublicWhisperAPI) HasIdentity(identity string) (bool, error) {
 	if s.w == nil {
 		return false, whisperOffLineErr
 	}
-	return s.w.HasIdentity(identity), nil
+	return s.w.HasIdentity(crypto.ToECDSAPub(common.FromHex(identity))), nil
 }
 
 // NewIdentity generates a new cryptographic identity for the client, and injects

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -142,7 +142,6 @@ func (self *Whisper) HasIdentity(input string) bool {
 	if len(crypto.FromECDSAPub(key)) == 65 {
 		return self.keys[string(crypto.FromECDSAPub(key))] != nil
 	}
-	fmt.Println(self.keys)
 	return self.keys[input] != nil
 }
 

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/event/filter"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
@@ -316,10 +317,11 @@ func (self *Whisper) open(envelope *Envelope) *Message {
 	// Iterate over the keys and try to decrypt the message
 	for _, key := range self.keys {
 		message, err := envelope.Open(key)
-		if err == nil {
+		switch err {
+		case nil:
 			message.To = &key.PublicKey
 			return message
-		} else {
+		case ecies.ErrInvalidPublicKey:
 			origMessage, err := envelope.Open(nil)
 			if err != nil {
 				return nil

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/event/filter"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
@@ -320,8 +319,12 @@ func (self *Whisper) open(envelope *Envelope) *Message {
 		if err == nil {
 			message.To = &key.PublicKey
 			return message
-		} else if err == ecies.ErrInvalidPublicKey {
-			return message
+		} else {
+			origMessage, err := envelope.Open(nil)
+			if err != nil {
+				return nil
+			}
+			return origMessage
 		}
 	}
 	// Failed to decrypt, don't return anything

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -137,8 +137,13 @@ func (self *Whisper) NewIdentity() *ecdsa.PrivateKey {
 
 // HasIdentity checks if the the whisper node is configured with the private key
 // of the specified public pair.
-func (self *Whisper) HasIdentity(key *ecdsa.PublicKey) bool {
-	return self.keys[string(crypto.FromECDSAPub(key))] != nil
+func (self *Whisper) HasIdentity(input string) bool {
+	key := crypto.ToECDSAPub(common.FromHex(input))
+	if len(crypto.FromECDSAPub(key)) == 65 {
+		return self.keys[string(crypto.FromECDSAPub(key))] != nil
+	}
+	fmt.Println(self.keys)
+	return self.keys[input] != nil
 }
 
 // GetIdentity retrieves the private key of the specified public identity.
@@ -147,9 +152,9 @@ func (self *Whisper) GetIdentity(key *ecdsa.PublicKey) *ecdsa.PrivateKey {
 }
 
 // InjectIdentity injects a manually added identity/key pair into the whisper keys
-func (self *Whisper) InjectIdentity(key *ecdsa.PrivateKey) error {
-	self.keys[string(crypto.FromECDSAPub(&key.PublicKey))] = key
-	if _, ok := self.keys[string(crypto.FromECDSAPub(&key.PublicKey))]; !ok {
+func (self *Whisper) InjectIdentity(address string, key *ecdsa.PrivateKey) error {
+	self.keys[address] = key
+	if _, ok := self.keys[address]; !ok {
 		return fmt.Errorf("key insert into keys map failed")
 	}
 	return nil

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -18,6 +18,7 @@ package whisper
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"sync"
 	"time"
 
@@ -143,6 +144,15 @@ func (self *Whisper) HasIdentity(key *ecdsa.PublicKey) bool {
 // GetIdentity retrieves the private key of the specified public identity.
 func (self *Whisper) GetIdentity(key *ecdsa.PublicKey) *ecdsa.PrivateKey {
 	return self.keys[string(crypto.FromECDSAPub(key))]
+}
+
+// InjectIdentity injects a manually added identity/key pair into the whisper keys
+func (self *Whisper) InjectIdentity(key *ecdsa.PrivateKey) error {
+	self.keys[string(crypto.FromECDSAPub(&key.PublicKey))] = key
+	if _, ok := self.keys[string(crypto.FromECDSAPub(&key.PublicKey))]; !ok {
+		return fmt.Errorf("key insert into keys map failed")
+	}
+	return nil
 }
 
 // Watch installs a new message handler to run in case a matching packet arrives

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -137,12 +137,8 @@ func (self *Whisper) NewIdentity() *ecdsa.PrivateKey {
 
 // HasIdentity checks if the the whisper node is configured with the private key
 // of the specified public pair.
-func (self *Whisper) HasIdentity(input string) bool {
-	key := crypto.ToECDSAPub(common.FromHex(input))
-	if len(crypto.FromECDSAPub(key)) == 65 {
-		return self.keys[string(crypto.FromECDSAPub(key))] != nil
-	}
-	return self.keys[input] != nil
+func (self *Whisper) HasIdentity(key *ecdsa.PublicKey) bool {
+	return self.keys[string(crypto.FromECDSAPub(key))] != nil
 }
 
 // GetIdentity retrieves the private key of the specified public identity.
@@ -151,11 +147,16 @@ func (self *Whisper) GetIdentity(key *ecdsa.PublicKey) *ecdsa.PrivateKey {
 }
 
 // InjectIdentity injects a manually added identity/key pair into the whisper keys
-func (self *Whisper) InjectIdentity(address string, key *ecdsa.PrivateKey) error {
-	self.keys[address] = key
-	if _, ok := self.keys[address]; !ok {
+func (self *Whisper) InjectIdentity(key *ecdsa.PrivateKey) error {
+
+	identity := string(crypto.FromECDSAPub(&key.PublicKey))
+	self.keys[identity] = key
+	if _, ok := self.keys[identity]; !ok {
 		return fmt.Errorf("key insert into keys map failed")
 	}
+
+	identityString := common.ToHex(crypto.FromECDSAPub(&key.PublicKey))
+	fmt.Printf("Injected identity into whisper: %s\n", identityString)
 	return nil
 }
 


### PR DESCRIPTION
Adds `addIdentity` into the whisper API in the context of the develop branch.  This implementation differs from the previous dev's implementation in error handling, function naming, and returns.

In addition, the last dev implemented a `createIdentity` method.  In my understanding this is not needed for our purposes and is in fact redundant.  That is, `newIdentity` already creates a key pair and automatically adds it to the whisper keys.  Is there a case where we would want to manually use this `createIdentity` function?  I think if anything we would either use the `newIdentity` function (which is equivalent to `createIdentity` + `addIdentity`) or use an HD wallet along with `addIdentity`.  Plus would returning this private and public pair to the console be less than ideal.  Am I missing something?

Anyway, this is the addIdentity functionality.

```
dwhitena@dirac:go-ethereum$ build/bin/geth -shh -noeth console
I0603 17:42:58.088418 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /home/dwhitena/.ethereum/chaindata
I0603 17:42:58.095332 ethdb/database.go:169] closed db:/home/dwhitena/.ethereum/chaindata
I0603 17:42:58.095778 p2p/server.go:311] Starting Server
I0603 17:43:00.667708 p2p/discover/udp.go:217] Listening, enode://dcb63a9c4dc6b87e4e9892c962411ff7b095a6a7daf5f28abb4a76b2f32542a6a81b8693d97789bba67861ece59c380cc8a46ea0b23c12a77ba9c2046b149f63@[::]:30303
I0603 17:43:00.667935 whisper/whisper.go:186] Whisper started
I0603 17:43:00.668303 p2p/server.go:554] Listening on [::]:30303
I0603 17:43:00.668491 node/node.go:298] IPC endpoint opened: /home/dwhitena/.ethereum/geth.ipc
instance: Geth/v1.5.0-unstable-fb80a048/linux/go1.6
> shh.
shh._requestManager shh.constructor     shh.hasIdentity     shh.post            
shh.addIdentity     shh.filter          shh.newGroup        shh.version         
shh.addToGroup      shh.getVersion      shh.newIdentity     
> shh.addIdentity('blah')
failed to convert identity to ECDSA: invalid hex string
    at web3.js:3119:20
    at web3.js:6030:15
    at web3.js:4995:36
    at <anonymous>:1:1

> shh.addIdentity('E9873D79C6D87DC0FB6A5778633389F4453213303DA61F20BD67FC233AA33262')
true
```