### PR TITLE
Fix for messaging with whisper identities

### DIFF
--- a/whisper/api.go
+++ b/whisper/api.go
@@ -178,6 +178,9 @@ func (s *PublicWhisperAPI) Post(args PostArgs) (bool, error) {
 
 	// construct whisper message with transmission options
 	message := NewMessage(common.FromHex(args.Payload))
+	if len(message.Payload) == 0 && len(args.Payload) > 0 {
+		message.Payload = []byte(args.Payload)
+	}
 	options := Options{
 		To:     crypto.ToECDSAPub(common.FromHex(args.To)),
 		TTL:    time.Duration(args.TTL) * time.Second,

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -307,11 +307,7 @@ func (self *Whisper) open(envelope *Envelope) *Message {
 			message.To = &key.PublicKey
 			return message
 		case ecies.ErrInvalidPublicKey:
-			origMessage, err := envelope.Open(nil)
-			if err != nil {
-				return nil
-			}
-			return origMessage
+			return message
 		}
 	}
 	// Failed to decrypt, don't return anything

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/event/filter"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
@@ -305,8 +304,12 @@ func (self *Whisper) open(envelope *Envelope) *Message {
 		if err == nil {
 			message.To = &key.PublicKey
 			return message
-		} else if err == ecies.ErrInvalidPublicKey {
-			return message
+		} else {
+			origMessage, err := envelope.Open(nil)
+			if err != nil {
+				return nil
+			}
+			return origMessage
 		}
 	}
 	// Failed to decrypt, don't return anything

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/event/filter"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
@@ -301,10 +302,11 @@ func (self *Whisper) open(envelope *Envelope) *Message {
 	// Iterate over the keys and try to decrypt the message
 	for _, key := range self.keys {
 		message, err := envelope.Open(key)
-		if err == nil {
+		switch err {
+		case nil:
 			message.To = &key.PublicKey
 			return message
-		} else {
+		case ecies.ErrInvalidPublicKey:
 			origMessage, err := envelope.Open(nil)
 			if err != nil {
 				return nil


### PR DESCRIPTION
This should close https://github.com/status-im/go-ethereum/issues/9.  Here are the specifics of the changes:

(i) The error handling used to parse the incoming messages did not take care of all possible cases, and did not allow returning a non-encrypted messages after erroring out on an attempted decryption. I changed this logic and it should be clear now.

(ii) The api (that powers the console) was not passing message payloads to the backend.  Because the payloads were not there, the decryption functions returned unexpected errors, that resulted in missing messages.  A small change to the handling of the API post function fixes this.