### PR TITLE
track running services for account injection

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -298,7 +298,7 @@ func makeDefaultExtra() []byte {
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
 func geth(ctx *cli.Context) {
-	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
+	node, _ := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	node.Wait()
 }
@@ -362,7 +362,7 @@ func initGenesis(ctx *cli.Context) {
 // same time.
 func console(ctx *cli.Context) {
 	// Create and start the node based on the CLI flags
-	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
+	node, _ := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 
 	// Attach to the newly started node, and either execute script or become interactive
@@ -395,7 +395,7 @@ func console(ctx *cli.Context) {
 // of the JavaScript files specified as command arguments.
 func execScripts(ctx *cli.Context) {
 	// Create and start the node based on the CLI flags
-	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
+	node, _ := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	defer node.Stop()
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -662,7 +662,7 @@ func MakePasswordList(ctx *cli.Context) []string {
 
 // MakeSystemNode sets up a local node, configures the services to launch and
 // assembles the P2P protocol stack.
-func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, *[]node.Service) {
+func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, []node.Service) {
 	// Avoid conflicting network flags
 	networks, netFlags := 0, []cli.BoolFlag{DevModeFlag, TestNetFlag, OlympicFlag}
 	for _, flag := range netFlags {
@@ -837,7 +837,7 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		}
 	}
 
-	return stack, &accountSync
+	return stack, accountSync
 }
 
 // SetupNetwork configures the system for either the main net or some test network.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -662,7 +662,7 @@ func MakePasswordList(ctx *cli.Context) []string {
 
 // MakeSystemNode sets up a local node, configures the services to launch and
 // assembles the P2P protocol stack.
-func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, []node.Service) {
+func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, *[]node.Service) {
 	// Avoid conflicting network flags
 	networks, netFlags := 0, []cli.BoolFlag{DevModeFlag, TestNetFlag, OlympicFlag}
 	for _, flag := range netFlags {
@@ -837,7 +837,7 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		}
 	}
 
-	return stack, accountSync
+	return stack, &accountSync
 }
 
 // SetupNetwork configures the system for either the main net or some test network.


### PR DESCRIPTION
Just a small change to return the account sync object I created.  This is necessary for the unlock bindings and possibly other things.