### PR TITLE
Logging redirect

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -298,7 +298,7 @@ func makeDefaultExtra() []byte {
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
 func geth(ctx *cli.Context) {
-	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
+	node, _ := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	node.Wait()
 }
@@ -362,7 +362,7 @@ func initGenesis(ctx *cli.Context) {
 // same time.
 func console(ctx *cli.Context) {
 	// Create and start the node based on the CLI flags
-	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
+	node, _ := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 
 	// Attach to the newly started node, and either execute script or become interactive
@@ -395,7 +395,7 @@ func console(ctx *cli.Context) {
 // of the JavaScript files specified as command arguments.
 func execScripts(ctx *cli.Context) {
 	// Create and start the node based on the CLI flags
-	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
+	node, _ := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	defer node.Stop()
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/les"
 	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/logger"
@@ -413,6 +414,13 @@ var (
 		Value: 110,
 	}
 )
+
+// DebugSetup sets up the debugging parameters such that logs can be retrieved when a
+// node is started via importing go-ethereum packages, as opposed to starting via CLI
+func DebugSetup(ctx *cli.Context) error {
+	err := debug.Setup(ctx)
+	return err
+}
 
 // MustMakeDataDir retrieves the currently requested data directory, terminating
 // if none (or the empty string) is specified. If the node is starting a testnet,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -662,7 +662,7 @@ func MakePasswordList(ctx *cli.Context) []string {
 
 // MakeSystemNode sets up a local node, configures the services to launch and
 // assembles the P2P protocol stack.
-func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, *[]node.Service) {
+func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, []node.Service) {
 	// Avoid conflicting network flags
 	networks, netFlags := 0, []cli.BoolFlag{DevModeFlag, TestNetFlag, OlympicFlag}
 	for _, flag := range netFlags {
@@ -837,7 +837,7 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		}
 	}
 
-	return stack, &accountSync
+	return stack, accountSync
 }
 
 // SetupNetwork configures the system for either the main net or some test network.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -662,7 +662,7 @@ func MakePasswordList(ctx *cli.Context) []string {
 
 // MakeSystemNode sets up a local node, configures the services to launch and
 // assembles the P2P protocol stack.
-func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, []node.Service) {
+func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) (*node.Node, *[]node.Service) {
 	// Avoid conflicting network flags
 	networks, netFlags := 0, []cli.BoolFlag{DevModeFlag, TestNetFlag, OlympicFlag}
 	for _, flag := range netFlags {
@@ -837,7 +837,7 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		}
 	}
 
-	return stack, accountSync
+	return stack, &accountSync
 }
 
 // SetupNetwork configures the system for either the main net or some test network.

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -84,6 +84,12 @@ func (*HandlerT) GcStats() *debug.GCStats {
 	return s
 }
 
+// SetLogDir overwrites the default log file utilized by glog
+func (h *HandlerT) SetLogDir(logDir string) error {
+	glog.SetLogDir(logDir)
+	return nil
+}
+
 // CpuProfile turns on CPU profiling for nsec seconds and writes
 // profile data to file.
 func (h *HandlerT) CpuProfile(file string, nsec uint) error {

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -43,6 +43,10 @@ var (
 		Usage: "Request a stack trace at a specific logging statement (e.g. \"block.go:271\")",
 		Value: glog.GetTraceLocation(),
 	}
+	logdirFlag = cli.StringFlag{
+		Name:  "logdir",
+		Usage: "Request that glog use the specified log dir location",
+	}
 	pprofFlag = cli.BoolFlag{
 		Name:  "pprof",
 		Usage: "Enable the pprof HTTP server",
@@ -73,7 +77,7 @@ var (
 
 // Flags holds all command-line flags required for debugging.
 var Flags = []cli.Flag{
-	verbosityFlag, vmoduleFlag, backtraceAtFlag,
+	verbosityFlag, vmoduleFlag, logdirFlag, backtraceAtFlag,
 	pprofFlag, pprofPortFlag,
 	memprofilerateFlag, blockprofilerateFlag, cpuprofileFlag, traceFlag,
 }
@@ -81,9 +85,17 @@ var Flags = []cli.Flag{
 // Setup initializes profiling and logging based on the CLI flags.
 // It should be called as early as possible in the program.
 func Setup(ctx *cli.Context) error {
+
 	// logging
+	if logDir := ctx.GlobalString(logdirFlag.Name); logDir != "" {
+		if err := Handler.SetLogDir(logDir); err != nil {
+			return err
+		}
+		glog.SetToStderr(false)
+	} else {
+		glog.SetToStderr(true)
+	}
 	glog.CopyStandardLogTo("INFO")
-	glog.SetToStderr(true)
 
 	// profiling, tracing
 	runtime.MemProfileRate = ctx.GlobalInt(memprofilerateFlag.Name)


### PR DESCRIPTION
This functionality allows us to redirect the logs from geth to a file on the android device.  A new flag `logdir` was introduced, where this directory string is passed to `glog` and utilized on init to create a log file in the specified location.

Note, if `logdir` is passed, geth will log there (i.e., not to stderr).
