### PR TITLE
Adds HD child derivation support (sub-accounts)

### DIFF
--- a/accounts/key.go
+++ b/accounts/key.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/pborman/uuid"
+	"github.com/status-im/status-go/src/extkeys"
 )
 
 const (
@@ -49,6 +50,10 @@ type Key struct {
 	// if whisper is enabled here, the address will be used as a whisper
 	// identity upon creation of the account or unlocking of the account
 	WhisperEnabled bool
+	// extended key is the root node for new hardened children i.e. sub-accounts
+	ExtendedKey *extkeys.ExtendedKey
+	// next index to be used for sub-account child derivation
+	SubAccountIndex uint32
 }
 
 type keyStore interface {
@@ -68,11 +73,13 @@ type plainKeyJSON struct {
 }
 
 type encryptedKeyJSONV3 struct {
-	Address        string     `json:"address"`
-	Crypto         cryptoJSON `json:"crypto"`
-	Id             string     `json:"id"`
-	Version        int        `json:"version"`
-	WhisperEnabled bool       `json:"whisperenabled"`
+	Address         string     `json:"address"`
+	Crypto          cryptoJSON `json:"crypto"`
+	Id              string     `json:"id"`
+	Version         int        `json:"version"`
+	WhisperEnabled  bool       `json:"whisperenabled"`
+	ExtendedKey     cryptoJSON `json:"extendedkey"`
+	SubAccountIndex uint32     `json:"subaccountindex"`
 }
 
 type encryptedKeyJSONV1 struct {
@@ -148,6 +155,41 @@ func newKeyFromECDSA(privateKeyECDSA *ecdsa.PrivateKey) *Key {
 		PrivateKey: privateKeyECDSA,
 	}
 	return key
+}
+
+func newKeyFromExtendedKey(extKey *extkeys.ExtendedKey) (*Key, error) {
+	var (
+		extChild1, extChild2 *extkeys.ExtendedKey
+		err                  error
+	)
+
+	if extKey.Depth == 0 { // we are dealing with master key
+		// CKD#1 - main account
+		extChild1, err = extKey.BIP44Child(extkeys.CoinTypeETH, 0)
+		if err != nil {
+			return &Key{}, err
+		}
+
+		// CKD#2 - sub-accounts root
+		extChild2, err = extKey.BIP44Child(extkeys.CoinTypeETH, 1)
+		if err != nil {
+			return &Key{}, err
+		}
+	} else { // we are dealing with non-master key, so it is safe to persist and extend from it
+		extChild1 = extKey
+		extChild2 = extKey
+	}
+
+	privateKeyECDSA := extChild1.ToECDSA()
+	id := uuid.NewRandom()
+	key := &Key{
+		Id:             id,
+		Address:        crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
+		PrivateKey:     privateKeyECDSA,
+		WhisperEnabled: true,
+		ExtendedKey:    extChild2,
+	}
+	return key, nil
 }
 
 // NewKeyForDirectICAP generates a key whose address fits into < 155 bits so it can fit

--- a/accounts/key_store_passphrase.go
+++ b/accounts/key_store_passphrase.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
 	"github.com/pborman/uuid"
+	"github.com/status-im/status-go/src/extkeys"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/crypto/scrypt"
 )
@@ -135,14 +136,61 @@ func EncryptKey(key *Key, auth string, scryptN, scryptP int) ([]byte, error) {
 		KDFParams:    scryptParamsJSON,
 		MAC:          hex.EncodeToString(mac),
 	}
+	encryptedExtendedKey, err := EncryptExtendedKey(key.ExtendedKey, auth, scryptN, scryptP)
+	if err != nil {
+		return nil, err
+	}
 	encryptedKeyJSONV3 := encryptedKeyJSONV3{
 		hex.EncodeToString(key.Address[:]),
 		cryptoStruct,
 		key.Id.String(),
 		version,
 		key.WhisperEnabled,
+		encryptedExtendedKey,
+		key.SubAccountIndex,
 	}
 	return json.Marshal(encryptedKeyJSONV3)
+}
+
+func EncryptExtendedKey(extKey *extkeys.ExtendedKey, auth string, scryptN, scryptP int) (cryptoJSON, error) {
+	if extKey == nil {
+		return cryptoJSON{}, nil
+	}
+	authArray := []byte(auth)
+	salt := randentropy.GetEntropyCSPRNG(32)
+	derivedKey, err := scrypt.Key(authArray, salt, scryptN, scryptR, scryptP, scryptDKLen)
+	if err != nil {
+		return cryptoJSON{}, err
+	}
+	encryptKey := derivedKey[:16]
+	keyBytes := []byte(extKey.String())
+
+	iv := randentropy.GetEntropyCSPRNG(aes.BlockSize) // 16
+	cipherText, err := aesCTRXOR(encryptKey, keyBytes, iv)
+	if err != nil {
+		return cryptoJSON{}, err
+	}
+	mac := crypto.Keccak256(derivedKey[16:32], cipherText)
+
+	scryptParamsJSON := make(map[string]interface{}, 5)
+	scryptParamsJSON["n"] = scryptN
+	scryptParamsJSON["r"] = scryptR
+	scryptParamsJSON["p"] = scryptP
+	scryptParamsJSON["dklen"] = scryptDKLen
+	scryptParamsJSON["salt"] = hex.EncodeToString(salt)
+
+	cipherParamsJSON := cipherparamsJSON{
+		IV: hex.EncodeToString(iv),
+	}
+
+	return cryptoJSON{
+		Cipher:       "aes-128-ctr",
+		CipherText:   hex.EncodeToString(cipherText),
+		CipherParams: cipherParamsJSON,
+		KDF:          "scrypt",
+		KDFParams:    scryptParamsJSON,
+		MAC:          hex.EncodeToString(mac),
+	}, nil
 }
 
 // DecryptKey decrypts a key from a json blob, returning the private key itself.
@@ -156,19 +204,41 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	var (
 		keyBytes, keyId []byte
 		err             error
+		extKeyBytes     []byte
+		extKey          *extkeys.ExtendedKey
 	)
+
+	subAccountIndex, ok := m["subaccountindex"].(float64)
+	if !ok {
+		subAccountIndex = 0
+	}
+
 	if version, ok := m["version"].(string); ok && version == "1" {
 		k := new(encryptedKeyJSONV1)
 		if err := json.Unmarshal(keyjson, k); err != nil {
 			return nil, err
 		}
 		keyBytes, keyId, err = decryptKeyV1(k, auth)
+		if err != nil {
+			return nil, err
+		}
+
+		extKey, err = extkeys.NewKeyFromString(extkeys.EmptyExtendedKeyString)
 	} else {
 		k := new(encryptedKeyJSONV3)
 		if err := json.Unmarshal(keyjson, k); err != nil {
 			return nil, err
 		}
 		keyBytes, keyId, err = decryptKeyV3(k, auth)
+		if err != nil {
+			return nil, err
+		}
+
+		extKeyBytes, err = decryptExtendedKey(k, auth)
+		if err != nil {
+			return nil, err
+		}
+		extKey, err = extkeys.NewKeyFromString(string(extKeyBytes))
 	}
 	// Handle any decryption errors and return the key
 	if err != nil {
@@ -176,10 +246,12 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	}
 	key := crypto.ToECDSA(keyBytes)
 	return &Key{
-		Id:             uuid.UUID(keyId),
-		Address:        crypto.PubkeyToAddress(key.PublicKey),
-		PrivateKey:     key,
-		WhisperEnabled: m["whisperenabled"].(bool),
+		Id:              uuid.UUID(keyId),
+		Address:         crypto.PubkeyToAddress(key.PublicKey),
+		PrivateKey:      key,
+		WhisperEnabled:  m["whisperenabled"].(bool),
+		ExtendedKey:     extKey,
+		SubAccountIndex: uint32(subAccountIndex),
 	}, nil
 }
 
@@ -257,6 +329,51 @@ func decryptKeyV1(keyProtected *encryptedKeyJSONV1, auth string) (keyBytes []byt
 		return nil, nil, err
 	}
 	return plainText, keyId, err
+}
+
+func decryptExtendedKey(keyProtected *encryptedKeyJSONV3, auth string) (plainText []byte, err error) {
+	if len(keyProtected.ExtendedKey.CipherText) == 0 {
+		return []byte(extkeys.EmptyExtendedKeyString), nil
+	}
+
+	if keyProtected.Version != version {
+		return nil, fmt.Errorf("Version not supported: %v", keyProtected.Version)
+	}
+
+	if keyProtected.ExtendedKey.Cipher != "aes-128-ctr" {
+		return nil, fmt.Errorf("Cipher not supported: %v", keyProtected.ExtendedKey.Cipher)
+	}
+
+	mac, err := hex.DecodeString(keyProtected.ExtendedKey.MAC)
+	if err != nil {
+		return nil, err
+	}
+
+	iv, err := hex.DecodeString(keyProtected.ExtendedKey.CipherParams.IV)
+	if err != nil {
+		return nil, err
+	}
+
+	cipherText, err := hex.DecodeString(keyProtected.ExtendedKey.CipherText)
+	if err != nil {
+		return nil, err
+	}
+
+	derivedKey, err := getKDFKey(keyProtected.ExtendedKey, auth)
+	if err != nil {
+		return nil, err
+	}
+
+	calculatedMAC := crypto.Keccak256(derivedKey[16:32], cipherText)
+	if !bytes.Equal(calculatedMAC, mac) {
+		return nil, ErrDecrypt
+	}
+
+	plainText, err = aesCTRXOR(derivedKey[:16], cipherText, iv)
+	if err != nil {
+		return nil, err
+	}
+	return plainText, err
 }
 
 func getKDFKey(cryptoJSON cryptoJSON, auth string) ([]byte, error) {


### PR DESCRIPTION
- part of https://github.com/status-im/status-go/issues/27
- `NewAccountUsingExtendedKey()` is refactored into `ImportExtendedKey(extKey, passphrase)` (which given HD key, verifies it using passphrase, and on success adds to key store - if not already there). The new method is more universal (thanks to @adrian-tiberius for idea), as it helps to:
  - create new master account
  - recover account details on new device
  - create child account (either from the root node, or from any level arbitrary extended key)
- Account key file is extended to include `CKD#2`, which serves as a root for the first-level children sub-accounts. `CKD#2` is encoded and serialized as `Key.ExtendedKey`.
- The new `Key.ExtendedKey` attribute is encrypted in the very similar way as account's private key is encrypted (AES128) i.e. we do not store `CKD#2` in plain text
- Finally, in addition to `Key.ExtendedKey`, we also track number of immediate children of the current account key i.e. sub-accounts. This allows us to add one more child without traversing addresses - we simply use the `Key.SubAccountIndex` to derive new child, then increment the index. In https://github.com/status-im/status-go/issues/28 we should account for `SubAccountIndex` attribute population (as the result of traversal, we should be able to know what the last child was) - that account discovery will be indispensable when recovering on a new device.