### PR TITLE
Remove padding from logmt

### DIFF
--- a/_assets/patches/0042-remove-logfmt-padding.patch
+++ b/_assets/patches/0042-remove-logfmt-padding.patch
@@ -1,0 +1,49 @@
+diff --git a/log/format.go b/log/format.go
+index 7902b296e..5a028263f 100644
+--- a/log/format.go
++++ b/log/format.go
+@@ -43,13 +43,6 @@ var locationEnabled uint32
+ // padded to to aid in alignment.
+ var locationLength uint32
+ 
+-// fieldPadding is a global map with maximum field value lengths seen until now
+-// to allow padding log contexts in a bit smarter way.
+-var fieldPadding = make(map[string]int)
+-
+-// fieldPaddingLock is a global mutex protecting the field padding map.
+-var fieldPaddingLock sync.RWMutex
+-
+ type Format interface {
+ 	Format(r *Record) []byte
+ }
+@@ -168,20 +161,6 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
+ 		if !ok {
+ 			k, v = errorKey, formatLogfmtValue(k, term)
+ 		}
+-
+-		// XXX: we should probably check that all of your key bytes aren't invalid
+-		fieldPaddingLock.RLock()
+-		padding := fieldPadding[k]
+-		fieldPaddingLock.RUnlock()
+-
+-		length := utf8.RuneCountInString(v)
+-		if padding < length {
+-			padding = length
+-
+-			fieldPaddingLock.Lock()
+-			fieldPadding[k] = padding
+-			fieldPaddingLock.Unlock()
+-		}
+ 		if color > 0 {
+ 			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=", color, k)
+ 		} else {
+@@ -189,9 +168,6 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
+ 			buf.WriteByte('=')
+ 		}
+ 		buf.WriteString(v)
+-		if i < len(ctx)-2 {
+-			buf.Write(bytes.Repeat([]byte{' '}, padding-length))
+-		}
+ 	}
+ 	buf.WriteByte('\n')
+ }

--- a/log/format.go
+++ b/log/format.go
@@ -43,13 +43,6 @@ var locationEnabled uint32
 // padded to to aid in alignment.
 var locationLength uint32
 
-// fieldPadding is a global map with maximum field value lengths seen until now
-// to allow padding log contexts in a bit smarter way.
-var fieldPadding = make(map[string]int)
-
-// fieldPaddingLock is a global mutex protecting the field padding map.
-var fieldPaddingLock sync.RWMutex
-
 type Format interface {
 	Format(r *Record) []byte
 }
@@ -168,20 +161,6 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
 		if !ok {
 			k, v = errorKey, formatLogfmtValue(k, term)
 		}
-
-		// XXX: we should probably check that all of your key bytes aren't invalid
-		fieldPaddingLock.RLock()
-		padding := fieldPadding[k]
-		fieldPaddingLock.RUnlock()
-
-		length := utf8.RuneCountInString(v)
-		if padding < length {
-			padding = length
-
-			fieldPaddingLock.Lock()
-			fieldPadding[k] = padding
-			fieldPaddingLock.Unlock()
-		}
 		if color > 0 {
 			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=", color, k)
 		} else {
@@ -189,9 +168,6 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
 			buf.WriteByte('=')
 		}
 		buf.WriteString(v)
-		if i < len(ctx)-2 {
-			buf.Write(bytes.Repeat([]byte{' '}, padding-length))
-		}
 	}
 	buf.WriteByte('\n')
 }


### PR DESCRIPTION
This padding was used to achieve consistent representation of the same outputs between multiple log entries. logfmt function was keeping an internal tracker of the longest observed output. And once observed , every output that was smaller than the longest one was padded to be same size as the longest one. For example:

Below you can see that at first length of the `msg` output is 14 and on the next line it is only 4. So the formatter will add a padding in second case. The same thing with `error`. It is present in the first line, but absent on the second, but output is padded.

```
t=2019-03-04T14:48:22+0200 lvl=trce msg="test test test" error=0x0000000000 after=0x0
t=2019-03-04T14:48:22+0200 lvl=trce msg=test             error=             after=0x0
```

Below are the log lines without padding (e.g. with changes from this branch):

```
t=2019-03-04T15:25:54+0200 lvl=trce msg="test test test" error=0x0000000000 after=0x0
t=2019-03-04T15:25:54+0200 lvl=trce msg=test error= after=0x0
```

In general, such padding may be a nice thing, but sometimes in our logs we have `msg` and `error` outputs that are really long. And once such output is observed, all other log lines with these outputs are screwed.
