### PR TITLE
Import single extended key 

### DIFF
--- a/_assets/patches/0044-add-import-single-extended-key
+++ b/_assets/patches/0044-add-import-single-extended-key
@@ -1,0 +1,70 @@
+diff --git a/accounts/keystore/key.go b/accounts/keystore/key.go
+index 03f7d59ea..1873c8218 100644
+--- a/accounts/keystore/key.go
++++ b/accounts/keystore/key.go
+@@ -47,12 +47,8 @@ type Key struct {
+ 	// we only store privkey as pubkey/address can be derived from it
+ 	// privkey in this struct is always in plaintext
+ 	PrivateKey *ecdsa.PrivateKey
+-	// ExtendedKey is the extended key of the PrivateKey itself, and it's used
+-	// to derive child keys.
++	// extended key is the root node for new hardened children i.e. sub-accounts
+ 	ExtendedKey *extkeys.ExtendedKey
+-	// SubAccountIndex is DEPRECATED
+-	// It was use in Status to keep track of the number of sub-account created
+-	// before having multi-account support.
+ 	// next index to be used for sub-account child derivation
+ 	SubAccountIndex uint32
+ }
+diff --git a/accounts/keystore/keystore.go b/accounts/keystore/keystore.go
+index defc35b4f..0a183aa68 100644
+--- a/accounts/keystore/keystore.go
++++ b/accounts/keystore/keystore.go
+@@ -38,7 +38,6 @@ import (
+ 	"github.com/ethereum/go-ethereum/core/types"
+ 	"github.com/ethereum/go-ethereum/crypto"
+ 	"github.com/ethereum/go-ethereum/event"
+-	"github.com/pborman/uuid"
+ 	"github.com/status-im/status-go/extkeys"
+ )
+ 
+@@ -460,39 +459,6 @@ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (acco
+ 	return ks.importKey(key, passphrase)
+ }
+ 
+-// ImportSingleExtendedKey imports an extended key setting it in both the PrivateKey and ExtendedKey fields
+-// of the Key struct.
+-// ImportExtendedKey is used in older version of Status where PrivateKey is set to be the BIP44 key at index 0,
+-// and ExtendedKey is the extended key of the BIP44 key at index 1.
+-func (ks *KeyStore) ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphrase string) (accounts.Account, error) {
+-	privateKeyECDSA := extKey.ToECDSA()
+-	id := uuid.NewRandom()
+-	key := &Key{
+-		Id:          id,
+-		Address:     crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
+-		PrivateKey:  privateKeyECDSA,
+-		ExtendedKey: extKey,
+-	}
+-
+-	// if account is already imported, return cached version
+-	if ks.cache.hasAddress(key.Address) {
+-		a := accounts.Account{
+-			Address: key.Address,
+-		}
+-		ks.cache.maybeReload()
+-		ks.cache.mu.Lock()
+-		a, err := ks.cache.find(a)
+-		ks.cache.mu.Unlock()
+-		if err != nil {
+-			zeroKey(key.PrivateKey)
+-			return a, err
+-		}
+-		return a, nil
+-	}
+-
+-	return ks.importKey(key, passphrase)
+-}
+-
+ // ImportExtendedKey stores ECDSA key (obtained from extended key) along with CKD#2 (root for sub-accounts)
+ // If key file is not found, it is created. Key is encrypted with the given passphrase.
+ func (ks *KeyStore) ImportExtendedKey(extKey *extkeys.ExtendedKey, passphrase string) (accounts.Account, error) {

--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -47,8 +47,12 @@ type Key struct {
 	// we only store privkey as pubkey/address can be derived from it
 	// privkey in this struct is always in plaintext
 	PrivateKey *ecdsa.PrivateKey
-	// extended key is the root node for new hardened children i.e. sub-accounts
+	// ExtendedKey is the extended key of the PrivateKey itself, and it's used
+	// to derive child keys.
 	ExtendedKey *extkeys.ExtendedKey
+	// SubAccountIndex is DEPRECATED
+	// It was use in Status to keep track of the number of sub-account created
+	// before having multi-account support.
 	// next index to be used for sub-account child derivation
 	SubAccountIndex uint32
 }

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/pborman/uuid"
 	"github.com/status-im/status-go/extkeys"
 )
 
@@ -456,6 +457,39 @@ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (acco
 	if ks.cache.hasAddress(key.Address) {
 		return accounts.Account{}, fmt.Errorf("account already exists")
 	}
+	return ks.importKey(key, passphrase)
+}
+
+// ImportSingleExtendedKey imports an extended key setting it in both the PrivateKey and ExtendedKey fields
+// of the Key struct.
+// ImportExtendedKey is used in older version of Status where PrivateKey is set to be the BIP44 key at index 0,
+// and ExtendedKey is the extended key of the BIP44 key at index 1.
+func (ks *KeyStore) ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphrase string) (accounts.Account, error) {
+	privateKeyECDSA := extKey.ToECDSA()
+	id := uuid.NewRandom()
+	key := &Key{
+		Id:          id,
+		Address:     crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
+		PrivateKey:  privateKeyECDSA,
+		ExtendedKey: extKey,
+	}
+
+	// if account is already imported, return cached version
+	if ks.cache.hasAddress(key.Address) {
+		a := accounts.Account{
+			Address: key.Address,
+		}
+		ks.cache.maybeReload()
+		ks.cache.mu.Lock()
+		a, err := ks.cache.find(a)
+		ks.cache.mu.Unlock()
+		if err != nil {
+			zeroKey(key.PrivateKey)
+			return a, err
+		}
+		return a, nil
+	}
+
 	return ks.importKey(key, passphrase)
 }
 

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -495,12 +495,14 @@ func (ks *KeyStore) ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphr
 
 // ImportExtendedKey stores ECDSA key (obtained from extended key) along with CKD#2 (root for sub-accounts)
 // If key file is not found, it is created. Key is encrypted with the given passphrase.
+// Deprecated: status-go is now using ImportSingleExtendedKey
 func (ks *KeyStore) ImportExtendedKey(extKey *extkeys.ExtendedKey, passphrase string) (accounts.Account, error) {
 	return ks.ImportExtendedKeyForPurpose(extkeys.KeyPurposeWallet, extKey, passphrase)
 }
 
 // ImportExtendedKeyForPurpose stores ECDSA key (obtained from extended key) along with CKD#2 (root for sub-accounts)
 // If key file is not found, it is created. Key is encrypted with the given passphrase.
+// Deprecated: status-go is now using ImportSingleExtendedKey
 func (ks *KeyStore) ImportExtendedKeyForPurpose(keyPurpose extkeys.KeyPurpose, extKey *extkeys.ExtendedKey, passphrase string) (accounts.Account, error) {
 	key, err := newKeyForPurposeFromExtendedKey(keyPurpose, extKey)
 	if err != nil {


### PR DESCRIPTION
Added `ImportSingleExtendedKey`, needed for multi-account.

We already added `ImportExtendedKey`, but this had more logic related to Status sub-accounts.
In case the imported key was a master key, the keystore file was filled with 2 keys:
* PrivateKey: the BIP44 key at index 0 derived from the master key
* ExtendedKey: the BIP44 key at index 1 derived from the master key

With this new method, we want to avoid having different keys in the same keystore file.
So PrivateKey will be the private key of ExtendedKey. 
ExtendedKey is a field we added on top of the original Key struct from go-ethereum.
It will be used to derive child keys.