### PR TITLE
update ImportSingleExtendedKey to return error if account already exists

### DIFF
--- a/_assets/patches/0046-import-single-extended-key-return-error.patch
+++ b/_assets/patches/0046-import-single-extended-key-return-error.patch
@@ -1,0 +1,49 @@
+diff --git a/accounts/keystore/keystore.go b/accounts/keystore/keystore.go
+index c1d8ca187..d9e92f982 100644
+--- a/accounts/keystore/keystore.go
++++ b/accounts/keystore/keystore.go
+@@ -43,9 +43,10 @@ import (
+ )
+ 
+ var (
+-	ErrLocked  = accounts.NewAuthNeededError("password or unlock")
+-	ErrNoMatch = errors.New("no key for given address or file")
+-	ErrDecrypt = errors.New("could not decrypt key with given password")
++	ErrLocked        = accounts.NewAuthNeededError("password or unlock")
++	ErrNoMatch       = errors.New("no key for given address or file")
++	ErrDecrypt       = errors.New("could not decrypt key with given password")
++	ErrAccountExists = errors.New("account already exists")
+ )
+ 
+ // KeyStoreType is the reflect type of a keystore backend.
+@@ -457,7 +458,7 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
+ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (accounts.Account, error) {
+ 	key := newKeyFromECDSA(priv)
+ 	if ks.cache.hasAddress(key.Address) {
+-		return accounts.Account{}, fmt.Errorf("account already exists")
++		return accounts.Account{}, ErrAccountExists
+ 	}
+ 	return ks.importKey(key, passphrase)
+ }
+@@ -476,20 +477,8 @@ func (ks *KeyStore) ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphr
+ 		ExtendedKey: extKey,
+ 	}
+ 
+-	// if account is already imported, return cached version
+ 	if ks.cache.hasAddress(key.Address) {
+-		a := accounts.Account{
+-			Address: key.Address,
+-		}
+-		ks.cache.maybeReload()
+-		ks.cache.mu.Lock()
+-		a, err := ks.cache.find(a)
+-		ks.cache.mu.Unlock()
+-		if err != nil {
+-			zeroKey(key.PrivateKey)
+-			return a, err
+-		}
+-		return a, nil
++		return accounts.Account{}, ErrAccountExists
+ 	}
+ 
+ 	return ks.importKey(key, passphrase)

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -476,20 +476,8 @@ func (ks *KeyStore) ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphr
 		ExtendedKey: extKey,
 	}
 
-	// if account is already imported, return cached version
 	if ks.cache.hasAddress(key.Address) {
-		a := accounts.Account{
-			Address: key.Address,
-		}
-		ks.cache.maybeReload()
-		ks.cache.mu.Lock()
-		a, err := ks.cache.find(a)
-		ks.cache.mu.Unlock()
-		if err != nil {
-			zeroKey(key.PrivateKey)
-			return a, err
-		}
-		return a, nil
+		return accounts.Account{}, fmt.Errorf("account already exists")
 	}
 
 	return ks.importKey(key, passphrase)

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -43,9 +43,10 @@ import (
 )
 
 var (
-	ErrLocked  = accounts.NewAuthNeededError("password or unlock")
-	ErrNoMatch = errors.New("no key for given address or file")
-	ErrDecrypt = errors.New("could not decrypt key with given password")
+	ErrLocked        = accounts.NewAuthNeededError("password or unlock")
+	ErrNoMatch       = errors.New("no key for given address or file")
+	ErrDecrypt       = errors.New("could not decrypt key with given password")
+	ErrAccountExists = errors.New("account already exists")
 )
 
 // KeyStoreType is the reflect type of a keystore backend.
@@ -457,7 +458,7 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (accounts.Account, error) {
 	key := newKeyFromECDSA(priv)
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, fmt.Errorf("account already exists")
+		return accounts.Account{}, ErrAccountExists
 	}
 	return ks.importKey(key, passphrase)
 }
@@ -477,7 +478,7 @@ func (ks *KeyStore) ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphr
 	}
 
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, fmt.Errorf("account already exists")
+		return accounts.Account{}, ErrAccountExists
 	}
 
 	return ks.importKey(key, passphrase)


### PR DESCRIPTION
This PR should fix https://github.com/status-im/status-go/issues/1896

To summarise: 

1. Create a new multi-account A.
2. In multi-account A, import a new key from mnemonic A (it will store `m/44'/60'/0'/0/0`. Importing a mnemonic inside a multi-account is currently only available in nightlies). 
3.  Logout.
4. Create new multi-account with mnemonic A (it will try store `m/44'/60'/0'/0/0`).

Step `4` should actually fails to avoid creating another keystore file with the already existing key, but potentially with a different password. 

Our old implementation wasn't overwriting the keystore, but it was returning the existing cached account `locked`. I think this was causing problem in our `status-go` accounts database.

In this PR I changed the behaviour of `ImportSingleExtendedKey` to return `account already exists` like `ImportECDSA` does.