### PR TITLE
drop throttling inbound connections

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -190,8 +190,7 @@ type Server struct {
 	checkpointAddPeer       chan *conn
 
 	// State of run loop and listenLoop.
-	lastLookup     time.Time
-	inboundHistory expHeap
+	lastLookup time.Time
 }
 
 type peerOpFunc func(map[enode.ID]*Peer)
@@ -924,12 +923,6 @@ func (srv *Server) checkInboundConn(fd net.Conn, remoteIP net.IP) error {
 		if srv.NetRestrict != nil && !srv.NetRestrict.Contains(remoteIP) {
 			return fmt.Errorf("not whitelisted in NetRestrict")
 		}
-		// Reject Internet peers that try too often.
-		srv.inboundHistory.expire(time.Now())
-		if !netutil.IsLAN(remoteIP) && srv.inboundHistory.contains(remoteIP.String()) {
-			return fmt.Errorf("too many attempts")
-		}
-		srv.inboundHistory.add(remoteIP.String(), time.Now().Add(inboundThrottleTime))
 	}
 	return nil
 }


### PR DESCRIPTION
This causes issues when connecting from networks behind NAT or just when reconnecting frequently.

I had to create a `patched/1.9.5` branch out of `patched/1.9` because it includes https://github.com/status-im/go-ethereum/commit/5e457aea which upgrade to `1.9.11` which we don't use yet.

See: https://github.com/status-im/status-go/pull/2146