### PR TITLE
chore: `passphrease` removed from the `Delete` function

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -234,23 +234,13 @@ func (ks *KeyStore) Accounts() []accounts.Account {
 	return ks.cache.accounts()
 }
 
-// Delete deletes the key matched by account if the passphrase is correct.
+// Delete deletes the key matched by account.
 // If the account contains no filename, the address must match a unique key.
-func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
-	// Decrypting the key isn't really necessary, but we do
-	// it anyway to check the password and zero out the key
-	// immediately afterwards.
-	a, key, err := ks.getDecryptedKey(a, passphrase)
-	if key != nil {
-		zeroKey(key.PrivateKey)
-	}
-	if err != nil {
-		return err
-	}
+func (ks *KeyStore) Delete(a accounts.Account) error {
 	// The order is crucial here. The key is dropped from the
 	// cache after the file is gone so that a reload happening in
 	// between won't insert it into the cache again.
-	err = os.Remove(a.URL.Path)
+	err := os.Remove(a.URL.Path)
 	if err == nil {
 		ks.cache.delete(a)
 		ks.refreshWallets()


### PR DESCRIPTION
Asking for a password when removing a key is not necessary.