### PR TITLE
[logger] add func `Output` as a convenient alias for write

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -130,6 +130,15 @@ type logger struct {
 	h   *swapHandler
 }
 
+// Output is a convenient alias for write, allowing for the modification of
+// the callDepth (number of stack frames to skip).
+// callDepth influences the reported line number of the log message.
+// A callDepth of zero reports the immediate caller of Output.
+// Non-zero callDepth skips as many stack frames.
+func (l *logger) Output(msg string, lvl Lvl, callDepth int, ctx ...interface{}) {
+	l.write(msg, lvl, ctx, callDepth+skipLevel)
+}
+
 func (l *logger) write(msg string, lvl Lvl, ctx []interface{}, skip int) {
 	l.h.Log(&Record{
 		Time: time.Now(),


### PR DESCRIPTION
This is preparatory work for optimizing the log output in status-go. We utilize both `zap` and the `go-ethereum log` as our logging dependencies. However, we lack a well-organized structure for our log content; for example, we do not currently include file location information for each log message. If we incorporate such details into our logs, it would enable us to filter messages by file location or module, among other criteria.