### PR TITLE
Add a dummy BlobTxType=0x3 implementation until go-ethereum rebased

### DIFF
--- a/core/types/dummy_tx_blob.go
+++ b/core/types/dummy_tx_blob.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"math/big"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DummyBlobTx struct {
+}
+
+// accessors for innerTx.
+func (tx *DummyBlobTx) txType() byte           { return BlobTxType }
+func (tx *DummyBlobTx) chainID() *big.Int      { return nil }
+func (tx *DummyBlobTx) accessList() AccessList { return AccessList{} }
+func (tx *DummyBlobTx) data() []byte           { return nil }
+func (tx *DummyBlobTx) gas() uint64            { return 0 }
+func (tx *DummyBlobTx) gasFeeCap() *big.Int    { return nil }
+func (tx *DummyBlobTx) gasTipCap() *big.Int    { return nil }
+func (tx *DummyBlobTx) gasPrice() *big.Int     { return nil }
+func (tx *DummyBlobTx) value() *big.Int        { return nil }
+func (tx *DummyBlobTx) nonce() uint64          { return 0 }
+func (tx *DummyBlobTx) to() *common.Address    { return nil }
+func (tx *DummyBlobTx) isSystemTx() bool       { return false }
+func (tx *DummyBlobTx) copy() TxData 		   { return nil }
+func (tx *DummyBlobTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int { return nil }
+func (tx *DummyBlobTx) isFake() bool           { return true }
+func (tx *DummyBlobTx) rawSignatureValues() (v, r, s *big.Int) { return nil, nil, nil }
+func (tx *DummyBlobTx) setSignatureValues(chainID, v, r, s *big.Int) {}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -45,6 +45,7 @@ const (
 	LegacyTxType = iota
 	AccessListTxType
 	DynamicFeeTxType
+	BlobTxType                    = 0x3
 	ArbitrumDepositTxType         = 100
 	ArbitrumUnsignedTxType        = 101
 	ArbitrumContractTxType        = 102
@@ -229,6 +230,9 @@ func (tx *Transaction) decodeTyped(b []byte, arbParsing bool) (TxData, error) {
 		var inner ArbitrumLegacyTxData
 		err := rlp.DecodeBytes(b[1:], &inner)
 		return &inner, err
+	case BlobTxType:
+		var inner DummyBlobTx
+		return &inner, nil
 	default:
 		return nil, ErrTxTypeNotSupported
 	}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -633,6 +633,8 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 			Value:   (*big.Int)(dec.Value),
 			Data:    *dec.Data,
 		}
+	case BlobTxType:
+		inner = &DummyBlobTx{}
 	default:
 		return ErrTxTypeNotSupported
 	}


### PR DESCRIPTION
It fixes other transactions not loaded that are in the same block with BlobTxType ones.